### PR TITLE
Add Ubuntu support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,6 +5,7 @@
 FROM ubuntu:bionic
 
 ARG KERNEL_RELEASE=
+ARG KERNEL_UNAME=
 ARG ZFS_VERSION=
 
 RUN apt-get update

--- a/README.md
+++ b/README.md
@@ -19,8 +19,14 @@ the following configuration options are available:
    is running with unknown patches to those sources. Defaults to `uname -r`. If
    you are building for a distro for the first time, you might want to submit
    a pull request to grab the appropriate kernel source.
+ * `-e KERNEL_UNAME=...` - Complete `uname -a` output identifying the kernel. For
+   some distros (e.g. Ubuntu), the variant is much easier to identify from the
+   full uname output, as there's not a constant string in `uname -r` output.
  * `-v path:/config` - Kernel configuration to use for building the kernel.
-   Must contain a single file, `config.gz`. Defaults to `/proc/config.gz`.
+   Must contain a single file, `config.gz`. Defaults to `/proc/config.gz`. This is
+   only needed in cases where we need to build the kernel from scratch; if we
+   can get pre-built kernel headers and objects via a distro-specific mechanism,
+   then we won't need this kernel configuration.
  * `-v path:/build` - Output where ZFS binaries (kernel modules and userland
    tools) will be placed, using their absolute path (e.g. `/build/sbin/zfs`)
 
@@ -43,6 +49,17 @@ be used:
 This builder only works with ZFS version 0.8.0 or later, as the spl repository
 has been merged and no longer needs to be built separately.
 
+## Supported distros
+
+The following distro-specific source mechanisms have been implemented:
+
+  * Linuxkit - Pulls source from `github.com/linuxkit/linux/archive/*`
+  * Ubuntu - Pull kernel headers, modules, and source via `apt`j
+
+In the event that the distro-specific mechanism cannot be determined, it will
+attempt to use vanilla sources from `kernel.org`, but it may or may not work
+depending on what distro-specific patches have been applied.
+
 ## How it works
 
 ZFS, like other kernel modules, has a dependency on the interfaces of the
@@ -57,13 +74,14 @@ To accomplish this, the ZFS builder does the following:
  1. Clone `https://github.com/zfsonlinux/zfs.git` into `/src/zfs` and
     checks out the appropriate tag (unless `/src/zfs` already exists)
  2. Build the kernel, if necessary. First check the kernel release variant and,
-    if a known distro, download kernel source through the distro-specific
-    means. Otherwise get the source from `www.kernel.org`.  Copy the `config.gz`
-    configuration to `/src/kernel/.config`. Build the kernel.
+    if a known distro, download pre-built kernel headers, objects, and/or source
+    through distro-specific means. Otherwise get the source from `www.kernel.org`.
+    If we need to build the kernel (vs. using a pre-built copy), copy the `config.gz`
+    configuration to `/src/kernel/.config` and build the kernel.
  3. Build `/src/zfs`
  4. Copy the resulting binaries to `/build`
 
-## <a id="contribute"></a>Contribute
+## Contribute
 
 1.  Fork the project.
 2.  Make your bug fix or new feature.
@@ -74,13 +92,13 @@ Contributions must be signed as `User Name <user@email.com>`. Make sure to
 [set up Git with user name and email address](https://git-scm.com/book/en/v2/Getting-Started-First-Time-Git-Setup).
 All development should be done on the `master` branch.
 
-#### <a id="code-of-conduct"></a>Code of Conduct
+#### Code of Conduct
 
 This project operates under the
 [Delphix Code of Conduct](https://delphix.github.io/code-of-conduct.html). By
 participating in this project you agree to abide by its terms.
 
-#### <a id="contributor-agreement"></a>Contributor Agreement
+#### Contributor Agreement
 
 All contributors are required to sign the Delphix Contributor agreement prior
 to contributing code to an open source repository. This process is handled
@@ -90,11 +108,11 @@ agreement. If not, you will be prompted to do so as part of the pull request
 process.
 
 
-## <a id="reporting_issues"></a>Reporting Issues
+## Reporting Issues
 
-Issues should be reported [here](https://github.com/delphix/automation-framework-demo/issues).
+Issues should be reported [here](https://github.com/delphix/zfs-builder/issues).
 
-## <a id="statement-of-support"></a>Statement of Support
+## Statement of Support
 
 This software is provided as-is, without warranty of any kind or commercial
 support through Delphix. See the associated license for additional details.
@@ -102,7 +120,7 @@ Questions, issues, feature requests, and contributions should be directed to
 the community as outlined in the
 [Delphix Community Guidelines](https://delphix.github.io/community-guidelines.html).
 
-## <a id="license"></a>License
+## License
 
 This is code is licensed under the Apache License 2.0. Full license is
 available [here](./LICENSE).


### PR DESCRIPTION
This adds distro-specific support for Ubuntu builds. With Ubuntu, we don't need to build the kernel from scratch but can instead pull the pre-built headers and modules and use those instead. The other change this required was to pass the full 'uname -a' output, so that we could detect the "Ubuntu" string without having to hand-code all of the various release strings.