### PR TITLE
Pull linuxkit kernel via docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,6 +10,7 @@ ARG ZFS_VERSION=
 
 RUN apt-get update
 
+# Tools to fetch and build source
 RUN apt-get install -y                                                       \
     git	                                                                     \
     curl xz-utils                                                            \
@@ -17,6 +18,27 @@ RUN apt-get install -y                                                       \
     autoconf automake libtool kmod                                           \
     zlib1g-dev uuid-dev libattr1-dev libblkid-dev libselinux-dev libudev-dev \
     libacl1-dev libaio-dev libdevmapper-dev libssl-dev libelf-dev
+
+# Python is not strictly required for ZFS, but eliminates a number of warnings
+RUN apt-get install -y                                                       \
+    python3 python3-distutils
+
+# Linuxkit binaries (such as fixdep) require musl
+RUN apt-get install -y musl
+
+# Linuxkit requires the ability to copy data from docker images
+RUN apt-get -y install apt-transport-https \
+     ca-certificates \
+     curl \
+     gnupg2 \
+     software-properties-common
+RUN curl -fsSL https://download.docker.com/linux/$(. /etc/os-release; echo "$ID")/gpg > /tmp/dkey; apt-key add /tmp/dkey
+RUN add-apt-repository \
+   "deb [arch=amd64] https://download.docker.com/linux/$(. /etc/os-release; echo "$ID") \
+   $(lsb_release -cs) \
+   stable"
+RUN apt-get update
+RUN apt-get -y install docker-ce
 
 RUN mkdir /src
 RUN mkdir /build


### PR DESCRIPTION
The previous method relied on downloading and building linuxkit source from github. Linuxkit stopped releasing linuxkit/linux in late 2018, requiring a different approach. The standard model is to get the binaries from the linuxkit/kernel docker images, which has the added benefit that we don't need to compile the kernel from source. The downside is that you now need to map the docker socket into the builder image, but that is a small inconvenience to being able to support all linuxkit versions.